### PR TITLE
Implements search_by_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Get module fields
 client.get_module_fields('MODULE_NAME')
 ```
 
+Search by module
+```
+client.search_by_module('SEARCH_STRING', ['MODULES_NAMES'])
+```
+
 ## Requirements
 - requests
 
@@ -74,7 +79,6 @@ python tests/test_client.py
 - logout
 - oauth_access
 - seamless_login
-- search_by_module
 - set_campaign_merge
 - set_document_revision
 - set_note_attachment

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client.get_module_fields('MODULE_NAME')
 
 Search by module
 ```
-client.search_by_module('SEARCH_STRING', ['MODULES_NAMES'])
+client.search_by_module('SEARCH_STRING', ['MODULE_NAMES'])
 ```
 
 ## Requirements

--- a/sugarcrm/client.py
+++ b/sugarcrm/client.py
@@ -294,8 +294,8 @@ class Client(object):
         favorites=False,
     ):
         """Given a list of modules to search and a search string, return the
-        id, module_name, along with the fields We will support Accounts, Bugs,
-        Cases, Contacts, Leads, Opportunities, Project, ProjectTask, Quotes
+        id, module_name, along with the fields. Supports Accounts, Bugs, Cases,
+        Contacts, Leads, Opportunities, Project, ProjectTask, Quotes.
      
         Args:
             search_string: string to search

--- a/sugarcrm/client.py
+++ b/sugarcrm/client.py
@@ -281,8 +281,51 @@ class Client(object):
     def seamless_login(self):
         raise NotImplementedError
 
-    def search_by_module(self):
-        raise NotImplementedError
+    @valid_parameters
+    def search_by_module(
+        self,
+        search_string,
+        modules,
+        offset=0,
+        max_results=0,
+        assigned_user_id="",
+        select_fields=[],
+        unified_search_only=False,
+        favorites=False,
+    ):
+        """Given a list of modules to search and a search string, return the
+        id, module_name, along with the fields We will support Accounts, Bugs,
+        Cases, Contacts, Leads, Opportunities, Project, ProjectTask, Quotes
+     
+        Args:
+            search_string: string to search
+            modules: array of modules to query
+            offset: a specified offset in the query
+            max_results: max number of records to return
+            assigned_user_id: a user id to filter all records by, leave empty
+                to exclude the filter
+            select_fields: An array of fields to return. If empty the default
+                return fields will be from the active list view defs.
+            unified_search_only: A boolean indicating if we should only search
+                against those modules participating in the unified search.
+            favorites: A boolean indicating if we should only search against
+                records marked as favorites.
+
+        Returns:
+            A dict.
+        """
+        data = [
+            self.session_id,
+            search_string,
+            modules,
+            offset,
+            max_results,
+            assigned_user_id,
+            select_fields,
+            unified_search_only,
+            favorites,
+        ]
+        return self._post("search_by_module", data)
 
     def set_campaign_merge(self):
         raise NotImplementedError


### PR DESCRIPTION
Hi,

I am currently building a command line interface to integrate SuiteCRM (built on SugarCRM) with mutt. For this I am using sugarcrm-python and needed the **search_by_module** API call. It was not yet implemented, so I did it myself.

Hope this helps.